### PR TITLE
Fix for: Fatal error: Can't use function return value in write context in /oc/common/classes/controller/panel/user.php

### DIFF
--- a/classes/controller/panel/user.php
+++ b/classes/controller/panel/user.php
@@ -160,7 +160,8 @@ class Controller_Panel_User extends Auth_Crud {
 	
 			if (core::post('password1')==core::post('password2'))
 			{
-				if(!empty(core::post('password1'))){
+				$password1_temp = core::post('password1'); // This temporary variable is needed - see http://stackoverflow.com/questions/1532693/weird-php-error-cant-use-function-return-value-in-write-context for why
+				if(!empty($password1_temp)){
 	
 					$user->password = core::post('password1');
 					$user->last_modified = Date::unix2mysql();


### PR DESCRIPTION
Fix for: Fatal error: Can't use function return value in write context in /oc/common/classes/controller/panel/user.php