### PR TITLE
Proposal: Check user role in a more readable way

### DIFF
--- a/classes/controller/forum.php
+++ b/classes/controller/forum.php
@@ -138,7 +138,7 @@ class Controller_Forum extends Controller {
 
         if(count($forums) == 0)
         {
-        	if(Auth::instance()->logged_in() AND Auth::instance()->get_user()->id_role == Model_Role::ROLE_ADMIN)
+        	if(Auth::instance()->logged_in() AND Auth::instance()->get_user()->is_admin())
         	{
         		Alert::set(Alert::INFO, __('Please, first create some Forums.'));
         		$this->redirect(Route::url('oc-panel',array('controller'=>'forum','action'=>'index')));

--- a/classes/controller/panel/user.php
+++ b/classes/controller/panel/user.php
@@ -166,7 +166,7 @@ class Controller_Panel_User extends Auth_CrudAjax {
 	public function action_changepass()
 	{
 		// only admins can change password
-		if ($this->request->post() AND $this->user->id_role == Model_Role::ROLE_ADMIN)
+		if ($this->request->post() AND $this->user->is_admin())
 		{
 			$user = new Model_User($this->request->param('id'));
 	

--- a/classes/model/oc/user.php
+++ b/classes/model/oc/user.php
@@ -805,7 +805,7 @@ class Model_OC_User extends ORM {
      */
     public function is_admin()
     {
-        if ($this->loaded() and $this->id_role==Model_Role::ROLE_ADMIN)
+        if ($this->loaded() AND $this->id_role==Model_Role::ROLE_ADMIN)
             return TRUE;
 
         return FALSE;
@@ -817,7 +817,7 @@ class Model_OC_User extends ORM {
      */
     public function is_moderator()
     {
-        if ($this->loaded() and $this->id_role==Model_Role::ROLE_MODERATOR)
+        if ($this->loaded() AND $this->id_role==Model_Role::ROLE_MODERATOR)
             return TRUE;
 
         return FALSE;
@@ -829,7 +829,7 @@ class Model_OC_User extends ORM {
      */
     public function is_translator()
     {
-        if ($this->loaded() and $this->id_role==Model_Role::ROLE_TRANSLATOR)
+        if ($this->loaded() AND $this->id_role==Model_Role::ROLE_TRANSLATOR)
             return TRUE;
 
         return FALSE;

--- a/classes/model/oc/user.php
+++ b/classes/model/oc/user.php
@@ -218,7 +218,7 @@ class Model_OC_User extends ORM {
 
 
     /**
-     * Check if user is admin
+     * Check the actual controller and action request and validates if the user has access to it
      * @todo    code something that you can show to your mom.
      * @param   string  $action
      * @return  boolean
@@ -812,7 +812,7 @@ class Model_OC_User extends ORM {
     }
 
     /**
-     * Check if the user is Admin.
+     * Check if the user is Moderator.
      * @return  boolean
      */
     public function is_moderator()
@@ -824,7 +824,7 @@ class Model_OC_User extends ORM {
     }
 
     /**
-     * Check if the user is Admin.
+     * Check if the user is Translator.
      * @return  boolean
      */
     public function is_translator()

--- a/classes/model/oc/user.php
+++ b/classes/model/oc/user.php
@@ -218,7 +218,7 @@ class Model_OC_User extends ORM {
 
 
     /**
-     * Check the actual controller and action request and validates if the user has access to it
+     * Check if user is admin
      * @todo    code something that you can show to your mom.
      * @param   string  $action
      * @return  boolean
@@ -382,10 +382,7 @@ class Model_OC_User extends ORM {
 
         if($user->loaded())
         {
-            if( !in_array($user->id_role, array(Model_Role::ROLE_ADMIN, 
-                                                Model_Role::ROLE_MODERATOR, 
-                                                Model_Role::ROLE_TRANSLATOR)) 
-                )
+            if ( ! $user->is_admin() AND ! $user->is_moderator() AND ! $user->is_translator())
             {
                 $user->status = self::STATUS_SPAM;
 
@@ -798,6 +795,42 @@ class Model_OC_User extends ORM {
             $ga = new PHPGangsta_GoogleAuthenticator();
             return $ga->getQRCodeGoogleUrl(core::config('general.site_name'), $this->google_authenticator);
         }
+
+        return FALSE;
+    }
+
+    /**
+     * Check if the user is Admin.
+     * @return  boolean
+     */
+    public function is_admin()
+    {
+        if ($this->loaded() and $this->id_role==Model_Role::ROLE_ADMIN)
+            return TRUE;
+
+        return FALSE;
+    }
+
+    /**
+     * Check if the user is Admin.
+     * @return  boolean
+     */
+    public function is_moderator()
+    {
+        if ($this->loaded() and $this->id_role==Model_Role::ROLE_MODERATOR)
+            return TRUE;
+
+        return FALSE;
+    }
+
+    /**
+     * Check if the user is Admin.
+     * @return  boolean
+     */
+    public function is_translator()
+    {
+        if ($this->loaded() and $this->id_role==Model_Role::ROLE_TRANSLATOR)
+            return TRUE;
 
         return FALSE;
     }

--- a/classes/oc/theme.php
+++ b/classes/oc/theme.php
@@ -753,7 +753,7 @@ class OC_Theme {
                 self::save();
                 HTTP::redirect(URL::current());
             }
-            elseif (Auth::instance()->get_user()->id_role == Model_Role::ROLE_ADMIN )
+            elseif (Auth::instance()->get_user()->is_admin())
             {
                 Alert::set(Alert::INFO, __('License validation error, please insert again.'));
                 HTTP::redirect(Route::url('oc-panel',array('controller'=>'theme', 'action'=>'license')));

--- a/views/oc-panel/elasticemail.php
+++ b/views/oc-panel/elasticemail.php
@@ -1,4 +1,4 @@
-<?if (core::cookie('elastic_alert')!=1  AND  Auth::instance()->get_user()->id_role==Model_Role::ROLE_ADMIN):?>
+<?if (core::cookie('elastic_alert')!=1  AND Auth::instance()->get_user()->is_admin()):?>
 <div class="alert alert-warning fade in">
         <button type="button" class="close" data-dismiss="alert" aria-hidden="true" onclick='setCookie("elastic_alert",1,365)'>×</button>
         <p>

--- a/views/oc-panel/pages/role/update.php
+++ b/views/oc-panel/pages/role/update.php
@@ -39,18 +39,16 @@
                     <div class="panel panel-default">
                         <div class="panel-body">
                             <h4>
-                                <div class="checkbox">
-                                    <label>
-                                        <input type="checkbox" name="<?=$controller.'|*'?>" <?=(in_array($controller.'.*',$access_in_use))?'checked="checked"':''?>> <?=$controller?>.*
-                                    </label>
+                                <div class="checkbox check-success">
+                                    <?=FORM::checkbox($controller.'|*', 'on', (bool) in_array($controller.'.*',$access_in_use), ['id' => $controller.'|*'])?>
+                                    <label for="<?=$controller.'|*'?>"><?=$controller?>.*</label>
                                 </div>
                             </h4>
                             <p>
                                 <?foreach ($actions as $action):?>
-                                <div class="checkbox">
-                                    <label>
-                                        <input type="checkbox" name="<?=$controller.'|'.$action?>" <?=(in_array($controller.'.'.$action,$access_in_use))?'checked="checked"':''?> > <?=$action?>
-                                    </label>
+                                <div class="checkbox check-success">
+                                    <?=FORM::checkbox($controller.'|'.$action, 'on', (bool) in_array($controller.'.'.$action,$access_in_use), ['id' => $controller.'|'.$action])?>
+                                    <label for="<?=$controller.'|'.$action?>"><?=$action?></label>
                                 </div>
                                 <?endforeach?>
                             </p>

--- a/views/oc-panel/pages/user/update.php
+++ b/views/oc-panel/pages/user/update.php
@@ -29,7 +29,7 @@
                 <?=$form->render()?>
             </div>
         </div>
-        <?if (Auth::instance()->get_user()->id_role == Model_Role::ROLE_ADMIN):?>
+        <?if (Auth::instance()->get_user()->is_admin()):?>
           <div class="panel panel-default">
               <div class="panel-heading" id="page-edit-profile">
                   <h3 class="panel-title"><?=__('Change password')?></h3>

--- a/views/pages/blog/listing.php
+++ b/views/pages/blog/listing.php
@@ -23,7 +23,7 @@
     	<div class="text-description blog-description"><?=Text::truncate_html($post->description, 255, NULL)?></div>
     	
 	    <a title="<?=HTML::chars($post->title)?>" href="<?=Route::url('blog', array('seotitle'=>$post->seotitle))?>"><i class="glyphicon glyphicon-share"></i><?=__('Read more')?></a>
-    	<?if ($user !== NULL AND $user!=FALSE AND $user->id_role == Model_Role::ROLE_ADMIN):?>
+    	<?if ($user !== NULL AND $user!=FALSE AND $user->is_admin()):?>
     		<br />
 			<a href="<?=Route::url('oc-panel', array('controller'=>'blog','action'=>'update','id'=>$post->id_post))?>"><?=__("Edit");?></a> |
 			<a href="<?=Route::url('oc-panel', array('controller'=>'blog','action'=>'delete','id'=>$post->id_post))?>" 

--- a/views/pages/error/default.php
+++ b/views/pages/error/default.php
@@ -57,7 +57,7 @@
       <div class="jumbotron">
         
         <?if (Auth::instance()->get_user()):?>
-        <?if (Auth::instance()->get_user()->id_role == Model_Role::ROLE_ADMIN):?>
+        <?if (Auth::instance()->get_user()->is_admin()):?>
             <p>Since you are logged in as admin only you can see this message:</p>
             <code><?=$message?></code>
             <p>It's been logged in Panel->Tools->Logs for more information regarding this error.</p>

--- a/views/pages/forum/list.php
+++ b/views/pages/forum/list.php
@@ -23,7 +23,7 @@
             <th><?=__('Last Message')?></th>
             <th><?=__('Replies')?></th>
             <?if (Auth::instance()->logged_in()):?>
-                <?if(Auth::instance()->get_user()->id_role==Model_Role::ROLE_ADMIN):?>
+                <?if(Auth::instance()->get_user()->is_admin()):?>
                     <th><?=__('Edit')?></th>
                 <?endif?>
             <?endif?>
@@ -50,7 +50,7 @@
                 <td width="15%"><span class="label label-warning pull-right"><?=Date::format($topic->last_message, core::config('general.date_format'))?></span></td>
                 <td width="5%"><span class="label label-success pull-right"><?=$replies?></span></td>
                 <?if (Auth::instance()->logged_in()):?>
-                    <?if(Auth::instance()->get_user()->id_role==Model_Role::ROLE_ADMIN):?>
+                    <?if(Auth::instance()->get_user()->is_admin()):?>
                         <td width="10%">
                             <a class="label label-warning" href="<?=Route::url('oc-panel', array('controller'=> 'topic', 'action'=>'update','id'=>$topic->id_post)) ?>">
                                 <span class="icon-edit icon-white glyphicon glyphicon-edit"></span>

--- a/views/pages/forum/search.php
+++ b/views/pages/forum/search.php
@@ -34,7 +34,7 @@
                     <td width="10%"><a title="<?=HTML::chars($topic->forum->name)?>" href="<?=Route::url('forum-list', array('forum'=>$topic->forum->seoname))?>"><?=$topic->forum->name?></a></td>
                     <td width="10%"><span class="label label-info pull-right"><?=Date::format($topic->created, core::config('general.date_format'))?></span></td>
                     <?if (Auth::instance()->logged_in()):?>
-                        <?if(Auth::instance()->get_user()->id_role==Model_Role::ROLE_ADMIN):?>
+                        <?if(Auth::instance()->get_user()->is_admin()):?>
                             <td width="10%">
                                 <a class="label label-warning" href="<?=Route::url('oc-panel', array('controller'=> 'topic', 'action'=>'update','id'=>$topic->id_post)) ?>">
                                     <span class="icon-edit icon-white glyphicon glyphicon-edit"></span>

--- a/views/pages/forum/topic.php
+++ b/views/pages/forum/topic.php
@@ -32,7 +32,7 @@
     </div>
     <div class="col-md-9 span6">
         <?if(Auth::instance()->logged_in()):?>
-            <?if(Auth::instance()->get_user()->id_role==Model_Role::ROLE_ADMIN):?>
+            <?if(Auth::instance()->get_user()->is_admin()):?>
                 <a class="label label-warning pull-right" href="<?=Route::url('oc-panel', array('controller'=> 'topic', 'action'=>'update','id'=>$topic->id_post)) ?>">
                     <i class="glyphicon icon-white icon-edit glyphicon-edit"></i>
                 </a>
@@ -73,7 +73,7 @@
     </div>
     <div class="col-md-9 span6">
     <?if(Auth::instance()->logged_in()):?>
-        <?if(Auth::instance()->get_user()->id_role==Model_Role::ROLE_ADMIN):?>
+        <?if(Auth::instance()->get_user()->is_admin()):?>
             <a class="label label-warning pull-right" href="<?=Route::url('oc-panel', array('controller'=> 'topic', 'action'=>'update','id'=>$reply->id_post)) ?>">
                 <i class="glyphicon icon-white icon-edit glyphicon-edit"></i>
             </a>


### PR DESCRIPTION
Instead of `$user->id_role == Model_Role::ROLE_ADMIN` do `$user->is_admin()`.

I think is cleaner and more readable.

* `$user->id_role == Model_Role::ROLE_ADMIN` => `$user->is_admin()`
* `$user->id_role == Model_Role::ROLE_MODERATOR` => `$user->is_moderator()`
* `$user->id_role == Model_Role::ROLE_TRANSLATOR` => `$user->is_translator()`