### PR TITLE
Fixes wrong anchor name on crud

### DIFF
--- a/views/oc-panel/crud/create.php
+++ b/views/oc-panel/crud/create.php
@@ -1,6 +1,6 @@
 <?php defined('SYSPATH') or die('No direct script access.');?>
 
-<h1 class="page-header page-title" id="crud-<?=__($name)?>"><?=__('New')?> <?=Text::ucfirst(__($name))?></h1>
+<h1 class="page-header page-title" id="crud-<?=$name?>"><?=__('New')?> <?=Text::ucfirst(__($name))?></h1>
 <hr>
 <div class="row">
 	<div class="col-md-12">

--- a/views/oc-panel/crud/update.php
+++ b/views/oc-panel/crud/update.php
@@ -1,6 +1,6 @@
 <?php defined('SYSPATH') or die('No direct script access.');?>
 
-<h1 class="page-header page-title" id="crud-<?=__($name)?>"><?=__('Update')?> <?=Text::ucfirst(__($name))?></h1>
+<h1 class="page-header page-title" id="crud-<?=$name?>"><?=__('Update')?> <?=Text::ucfirst(__($name))?></h1>
 <hr>
 <div class="row">
 	<div class="col-md-12">

--- a/views/oc-panel/pages/blog/update.php
+++ b/views/oc-panel/pages/blog/update.php
@@ -5,7 +5,7 @@
             <?=__('Preview')?>
         </a>
 	<?endif?>
-<h1 class="page-header page-title" id="crud-<?=__($name)?>"><?=__('Edit Blog Post')?></h1>
+<h1 class="page-header page-title" id="crud-<?=$name?>"><?=__('Edit Blog Post')?></h1>
 <hr>
 <?//var_dump($form)?>
 

--- a/views/oc-panel/pages/user/update.php
+++ b/views/oc-panel/pages/user/update.php
@@ -1,5 +1,5 @@
 <?php defined('SYSPATH') or die('No direct script access.');?>
-<h1 class="page-header page-title" id="crud-<?=__($name)?>"><?=__('Update')?> <?=Text::ucfirst(__($name))?></h1>
+<h1 class="page-header page-title" id="crud-<?=$name?>"><?=__('Update')?> <?=Text::ucfirst(__($name))?></h1>
 <hr>
   <p>
     <?$controllers = Model_Access::list_controllers()?>


### PR DESCRIPTION
Wrong anchor name when translation is distinct to English. We check anchor on https://github.com/open-classifieds/openclassifieds2/blob/master/themes/default/js/oc-panel/theme.init.js#L36